### PR TITLE
Print to console error with coverage issue for grader visibility

### DIFF
--- a/tests/jest_coverage_reporter.ts
+++ b/tests/jest_coverage_reporter.ts
@@ -12,3 +12,5 @@ const totalSum = ['lines']
   .reduce((a, b) => a + b, 0)
 const avgCoverage = totalSum
 console.log(`Coverage: ${avgCoverage.toFixed(2)}%`)
+console.log("\n\nCoverage number appears lower than real value, if you look in coverage/lcov-report/index.html");
+console.log("it shows code that definitely executes as not being covered. There is an open issue to chase this down.");


### PR DESCRIPTION
Simple print for ./run test in jest_coverage_reporter to show visibility of #56 !