### PR TITLE
Commented out unused functions in GithubRepository class

### DIFF
--- a/src/github_repository.ts
+++ b/src/github_repository.ts
@@ -118,6 +118,8 @@ export class GithubRepository extends Repository {
 		});
 	}
 	
+	// Commenting out because unused - Responsive Maintainer task incomplete by Robert.
+	/*
 	async get_issues():Promise<Issue[]> {
 		type IteratorResponseType = GetResponseTypeFromEndpointMethod<
 		typeof this.octokit.paginate.iterator>;
@@ -163,7 +165,8 @@ export class GithubRepository extends Repository {
 			resolve(rv);
 		});
 	} 
-
+	*/
+	
 	async get_license():Promise<string | null> {
 		type ContentResponseType = GetResponseTypeFromEndpointMethod<
 		typeof this.octokit.rest.licenses.getForRepo>;

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -30,7 +30,12 @@ export abstract class Repository {
 		MIT and LGPL in the readme in the license metric.
 	*/
     abstract get_license():Promise<string | null>;
+    
+    // Commenting out because unused - Responsive Maintainer task incomplete by Robert.
+    /*
     abstract get_issues():Promise<Issue[]>;
+    */
+   
 	/* get_readme() function
 		returns absolute filepath of downloaded readme in this project
 		make sure to error check for null string return.


### PR DESCRIPTION
as well as in Repository abstract class
because Responsive Maintainer was not implemented by the assigned person.