### PR TITLE
Version pinning metric

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/node_modules
+/build

--- a/src/github_repository.ts
+++ b/src/github_repository.ts
@@ -143,8 +143,6 @@ export class GithubRepository extends Repository {
 			}
 		}
 
-		console.log(response?.data.length)
-
 		// uses octokit REST API to fetch issues list
 		/* const iterator:IteratorResponseType = this.octokit.paginate.iterator(this.octokit.rest.issues.listForRepo, {
 		  owner: this.owner,
@@ -352,13 +350,13 @@ export class GithubRepository extends Repository {
 		});
 	}
 
-	async get_package_json():Promise<string | null> {
+	async get_package_json():Promise<any | null> {
 		type ContentResponseType = GetResponseTypeFromEndpointMethod<
 		typeof this.octokit.rest.repos.getContent>;
 		type ContentResponseDataType = GetResponseDataTypeFromEndpointMethod<
 		typeof this.octokit.rest.repos.getContent>; 
 		var cdata:ContentResponseDataType;
-		var rv:string|null = null;
+		var rv:any|null = null;
 
 		// uses octokit REST API to fetch license data
 		try {

--- a/src/github_repository.ts
+++ b/src/github_repository.ts
@@ -350,7 +350,42 @@ export class GithubRepository extends Repository {
 		return new Promise((resolve) => {
 			resolve(rv);
 		});
-	}                                                                                                                          
+	}
+
+	async get_package_json():Promise<string | null> {
+		type ContentResponseType = GetResponseTypeFromEndpointMethod<
+		typeof this.octokit.rest.repos.getContent>;
+		type ContentResponseDataType = GetResponseDataTypeFromEndpointMethod<
+		typeof this.octokit.rest.repos.getContent>; 
+		var cdata:ContentResponseDataType;
+		var rv:string|null = null;
+
+		// uses octokit REST API to fetch license data
+		try {
+			var content:ContentResponseType = await this.octokit.rest.repos.getContent({
+			  owner: this.owner,
+			  repo: this.repo,
+			  path: 'package.json',
+			});
+			cdata = content.data;
+			logger.log('info', "Fetched package file from " + this.owner + "/" + this.repo);
+		} catch (error) {
+			logger.log('debug', "Could not fetch package file from " + this.owner + "/" + this.repo);
+			return new Promise((resolve) => {
+				resolve(rv);
+			});	
+		}
+
+		// this does not work for some reason - debug
+		// this is a workaround since we cannot seem to access object properties of cdata above
+		var jdata = JSON.parse(JSON.stringify(cdata));
+		var decoded:string = Buffer.from(jdata.content, 'base64').toString('ascii')
+		var pkg = JSON.parse(decoded)
+
+		return new Promise((resolve) => {
+			resolve(pkg);
+		});	
+	}
  }                                                                                            
  
  

--- a/src/github_repository.ts
+++ b/src/github_repository.ts
@@ -119,7 +119,7 @@ export class GithubRepository extends Repository {
 	}
 	
 	// Commenting out because unused - Responsive Maintainer task incomplete by Robert.
-	/*
+	
 	async get_issues():Promise<Issue[]> {
 		type IteratorResponseType = GetResponseTypeFromEndpointMethod<
 		typeof this.octokit.paginate.iterator>;
@@ -165,7 +165,7 @@ export class GithubRepository extends Repository {
 			resolve(rv);
 		});
 	} 
-	*/
+	
 	
 	async get_license():Promise<string | null> {
 		type ContentResponseType = GetResponseTypeFromEndpointMethod<

--- a/src/index.ts
+++ b/src/index.ts
@@ -387,7 +387,7 @@ export function get_weighted_sum(scores:ScoresWithoutNet):ScoresWithNet {
 	}
 	if (responsive_maintainer_score_calc == null) {
 		responsive_maintainer_score_calc = 0;
-		responsive_maintainer_score_disp = -1;
+		responsive_maintainer_score_disp = 0;
 	}
 	else {
 		responsive_maintainer_score_disp = responsive_maintainer_score_calc;

--- a/src/metric.ts
+++ b/src/metric.ts
@@ -397,65 +397,27 @@ export class CorrectnessMetric extends Metric {
 export class ResponsiveMetric extends Metric {
     async get_metric(repo: Repository):Promise<GroupMetric> {
         var final_score:NullNum = null;
-        /*
+        
         const issue_arr:Issue[] = await repo.get_issues(); // get all issues
 
         var tot_response_time = 0; // time measured in ms
-        var num_events = 0;
-
-        for (var issue of issue_arr) {
-
-            if(issue.created_at == null) {
-                logger.log("info", "%Issue does not have creation date") // issue was never created, skip it
-                continue
-            }
-
-            if(issue.total_events == null || issue.total_events == 0) {
-                logger.log('info', "issue has no events")
-                num_events += 1
-            } else {
-                num_events += issue.total_events; // Add number of events to total count
-            }
-
-            var created_time = new Date(issue.created_at).getTime() // Get time issue was created
-            
-
-            if(issue.closed_at != null) {
-                tot_response_time += new Date(issue.closed_at).getTime() - created_time;
-            } else if(issue.updated_at != null) {
-                tot_response_time += new Date(issue.updated_at).getTime() - created_time;
-            } else {
-                logger.log('debug', "Issue never updated or closed");
-                tot_response_time += 120000000; // add 2 weeks in time, should round to 1.0 in score
-            }
-            
-        }
-
-        // if there were no events, responsiveness is ambiguous, return medium value
-        if(num_events == 0) {
-            logger.log('info', 'No events in issue list');
-            final_score = 0.5;
-        }
+		const issueCount = issue_arr.length;
+		const responsiveIssues = issue_arr.filter((issue) => issue.created_at !== issue.updated_at);
+		const responsiveIssueCount = responsiveIssues.length;
 
         // get avg response time, then score, round to 2 digits
         if(final_score == null) {
             // get avg response time for repo Ex: originally in ms, the average response time for cloudbinary is 967.4 hours
-            logger.log('debug', "Premodified score: %d", tot_response_time / num_events);
-            logger.log("debug", "avg response time in h: %d", (tot_response_time/num_events/ 3600000));
+            logger.log('debug', "Issue Count: %d", issueCount);
+            logger.log("debug", "Responsive Issue Count: %d", responsiveIssueCount);
+			logger.log("debug", "Responsiveness: %d", responsiveIssueCount / issueCount);
 
             // round final score calc Ex: That will result in a score so low it rounds to 0
-            final_score = Math.round(this.sigmoid(tot_response_time / num_events / 3600000)*100)/100; 
+            final_score = issueCount === 0 ? 0 : responsiveIssueCount / issueCount;
         }
-        */
+        
         return new Promise((resolve) => {
 			resolve(new GroupMetric(repo.url, "RESPONSIVE_SCORE", final_score));
 		});
     }
-    /*
-    // Takes value in ms, numbers less than 1 hour are extremely close to 0
-    // numbers greater than 1 week are extremely close to 1
-    sigmoid(x: number) {
-        return (-1/(1 + Math.exp(0.04*(-x+168)))+1);
-    }
-    */
 }

--- a/src/metric.ts
+++ b/src/metric.ts
@@ -400,7 +400,6 @@ export class ResponsiveMetric extends Metric {
         
         const issue_arr:Issue[] = await repo.get_issues(); // get all issues
 
-        var tot_response_time = 0; // time measured in ms
 		const issueCount = issue_arr.length;
 		const responsiveIssues = issue_arr.filter((issue) => issue.created_at !== issue.updated_at);
 		const responsiveIssueCount = responsiveIssues.length;

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -32,9 +32,9 @@ export abstract class Repository {
     abstract get_license():Promise<string | null>;
     
     // Commenting out because unused - Responsive Maintainer task incomplete by Robert.
-    /*
+    
     abstract get_issues():Promise<Issue[]>;
-    */
+    
    
 	/* get_readme() function
 		returns absolute filepath of downloaded readme in this project

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -46,5 +46,5 @@ export abstract class Repository {
     abstract get_readme():Promise<string | null>;
     abstract get_contributors_stats():Promise<Contributions>;
 
-	abstract get_package_json():Promise<string | null>;
+	abstract get_package_json():Promise<any | null>;
 }

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -45,4 +45,6 @@ export abstract class Repository {
 	*/
     abstract get_readme():Promise<string | null>;
     abstract get_contributors_stats():Promise<Contributions>;
+
+	abstract get_package_json():Promise<string | null>;
 }

--- a/tests/scores.test.ts
+++ b/tests/scores.test.ts
@@ -29,7 +29,7 @@ global.logger = logger;
 describe('Get weighted sum test', () => {
 	test('all 1', () => {
 		var no_net:ScoresWithoutNet = new ScoresWithoutNet('https://github.com/cloudinary/cloudinary_npm',
-		1, 1, 1, 1, 1);
+		1, 1, 1, 1, 1, 1);
 		const nscore = get_weighted_sum(no_net);
 		expect(nscore.net_score).toEqual(1);
 	});
@@ -38,7 +38,7 @@ describe('Get weighted sum test', () => {
 describe('Get weighted sum test', () => {
 	test('license 0', () => {
 		var no_net:ScoresWithoutNet = new ScoresWithoutNet('https://github.com/cloudinary/cloudinary_npm',
-		0, 1, 1, 1, 1);
+		0, 1, 1, 1, 1, 1);
 		const nscore = get_weighted_sum(no_net);
 		expect(nscore.net_score).toEqual(0);
 	});
@@ -47,7 +47,7 @@ describe('Get weighted sum test', () => {
 describe('Get weighted sum test', () => {
 	test('all 0', () => {
 		var no_net:ScoresWithoutNet = new ScoresWithoutNet('https://github.com/cloudinary/cloudinary_npm',
-		0, 0, 0, 0, 0);
+		0, 0, 0, 0, 0, 0);
 		const nscore = get_weighted_sum(no_net);
 		expect(nscore.net_score).toEqual(0);
 	});
@@ -56,7 +56,7 @@ describe('Get weighted sum test', () => {
 describe('Get weighted sum test', () => {
 	test('null implemented score', () => {
 		var no_net:ScoresWithoutNet = new ScoresWithoutNet('https://github.com/cloudinary/cloudinary_npm',
-		null, 0, 0, 0, 0);
+		null, 0, 0, 0, 0, 0);
 		const nscore = get_weighted_sum(no_net);
 		expect(nscore.license_score).toEqual(0);
 	});
@@ -66,7 +66,7 @@ describe('Get weighted sum test', () => {
 describe('Get weighted sum test', () => {
 	test('null unimplemented score', () => {
 		var no_net:ScoresWithoutNet = new ScoresWithoutNet('https://github.com/cloudinary/cloudinary_npm',
-		0, 0, 0, 0, null);
+		0, 0, 0, 0, null, 0);
 		const nscore = get_weighted_sum(no_net);
 		expect(nscore.responsive_maintainer_score).toEqual(-1);
 	});


### PR DESCRIPTION
'The fraction of dependencies that are pinned to at least a specific major+minor version, e.g., version 2.3.X of a package. (If there are zero dependencies, they should receive a 1.0 rating. If there are two dependencies, one pinned to this degree, then they should receive a ½ = 0.5 rating)'

Might want to change up the weighting on this at a later point since it's uncommon for dependencies to be pinned this way, so the score for this particular metric usually ends up low.